### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,8 @@ jobs:
   tag-release:
     name: Tag
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/invopop/datauri/security/code-scanning/2](https://github.com/invopop/datauri/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. The workflow requires `contents: write` to push tags to the repository. We will set this permission explicitly while keeping all other permissions at their default `none` level. This ensures the workflow has only the permissions it needs to function correctly.

The `permissions` block will be added at the job level (`tag-release`) to scope the permissions to this specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
